### PR TITLE
tssilomon: use #!/bin/sh as interpreter

### DIFF
--- a/script/tssilomon
+++ b/script/tssilomon
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 grep "ts-silo=1" /proc/cmdline > /dev/null 2>&1
 


### PR DESCRIPTION
Switch to /bin/sh as the script content is POSIX compliant.

This avoids pulling a nonessential dependency (many systems solely rely on Busybox ash), and facilitates integration into systems where GPLv3 licensed components are a challenge.