### PR TITLE
tsmictoctl fixes

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,6 @@
 adc8390
 gpioctl
+isl12020rtc
 load_fpga
 nvramctl
 rtctemp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,8 +8,6 @@ tshwctl_SOURCES = tshwctl.c fpga.c
 tshwctl_CPPFLAGS = $(LIBGPIOD_CFLAGS)
 tshwctl_LDADD = $(LIBGPIOD_LIBS) -lm
 
-tsmicroctl_SOURCES = tsmicroctl.c
-tsmicroctl_CPPFLAGS = -DCTL
-tsmicroctl_LDADD =
+tsmicroctl_SOURCES = tsmicroctl.c micro.c
 
 bin_PROGRAMS = tshwctl tsmicroctl isl12020rtc

--- a/src/isl12020rtc.c
+++ b/src/isl12020rtc.c
@@ -136,7 +136,6 @@ void rtc_tsv2b_read(int i2cfd, struct tm *ts)
 {
 	time_t now;
 	uint8_t data[5];
-	int year;
 
 	rtc_read(i2cfd, 0x16, data, 5);
 	time(&now);
@@ -154,7 +153,6 @@ void rtc_tsb2v_read(int i2cfd, struct tm *ts)
 {
 	time_t now;
 	uint8_t data[5];
-	int year;
 
 	rtc_read(i2cfd, 0x1b, data, 5);
 	time(&now);

--- a/src/micro.c
+++ b/src/micro.c
@@ -1,0 +1,183 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <linux/i2c.h>
+#include <linux/i2c-dev.h>
+
+int micro_init(int i2cbus, int i2caddr)
+{
+	static int fd = -1;
+	char i2c_bus_path[20];
+
+	if (fd != -1)
+		return fd;
+
+	snprintf(i2c_bus_path, sizeof(i2c_bus_path), "/dev/i2c-%d", i2cbus);
+	fd = open(i2c_bus_path, O_RDWR);
+	if (fd < 0) {
+		perror("Couldn't open i2c device");
+		goto out;
+	}
+
+	/*
+	 * We use force because there is typically a driver attached. This is
+	 * safe because we are using only i2c_msgs and not read()/write() calls
+	 */
+	if (ioctl(fd, I2C_SLAVE_FORCE, i2caddr) < 0) {
+		perror("Supervisor did not ACK");
+		close(fd);
+		fd = -1;
+	}
+
+out:
+	return fd;
+}
+
+/*
+ * Returns < 0 on failure, 0 on success
+ * Data read is inserted in to *data
+ */
+int speekstream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size)
+{
+	struct i2c_rdwr_ioctl_data packets;
+	struct i2c_msg msgs[2];
+	int ret;
+
+	msgs[0].addr = i2caddr;
+	msgs[0].flags = 0;
+	msgs[0].len = 2;
+	msgs[0].buf = (uint8_t *)&addr;
+
+	msgs[1].addr = i2caddr;
+	msgs[1].flags = I2C_M_RD;
+	msgs[1].len = size;
+	msgs[1].buf = (uint8_t *)data;
+
+	packets.msgs = msgs;
+	packets.nmsgs = 2;
+
+	/* I2C_RDWR will return < 0 on error, or the number of messages that
+	 * were transferred. We should always have two since we are only ever
+	 * sending a write followed by a read.
+	 */
+	ret = ioctl(i2cfd, I2C_RDWR, &packets);
+	if (ret < 0)
+		perror("Unable to read data");
+	else if (ret == 2)
+		ret = 0;
+	else
+		ret = -1;
+
+	return ret;
+}
+
+/*
+ * Returns < 0 on failure, 0 on success
+ */
+int spokestream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size)
+{
+	struct i2c_rdwr_ioctl_data packets;
+	struct i2c_msg msg;
+	uint8_t *outdata;
+	int ret;
+
+	/*
+	 * Linux only supports 4k transactions at a time, and we need
+	 * two bytes for the address
+	 */
+	assert(size <= 4094);
+	outdata = malloc(size + 2);
+
+	memcpy(outdata, &addr, 2);
+	memcpy(&outdata[2], data, size);
+
+	msg.addr = i2caddr;
+	msg.flags = 0;
+	msg.len = 2 + size;
+	msg.buf = outdata;
+
+	packets.msgs = &msg;
+	packets.nmsgs = 1;
+
+	ret = ioctl(i2cfd, I2C_RDWR, &packets);
+	free(outdata);
+
+	/* I2C_RDWR will return < 0 on error, or the number of messages that
+	 * were transferred. We should always have one since we are only ever
+	 * sending a single transfer.
+	 */
+	if (ret < 0)
+		perror("Unable to send data");
+	else if (ret == 1)
+		ret = 0;
+	else
+		ret = -1;
+
+	return ret;
+}
+
+/*
+ * Since we are not expecting any data, simply pass along the return value
+ * of the stream write.
+ *
+ * < 0 on failure, 0 on success
+ */
+int spoke16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t data)
+{
+	return spokestream16(i2cfd, i2caddr, addr, &data, 2);
+}
+
+/*
+ * Returns < 0 on failure
+ */
+int speek16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data)
+{
+	return speekstream16(i2cfd, i2caddr, addr, data, 2);
+}
+
+/*
+ * Returns 0 on success, < 0 on all other failures.
+ */
+static int __v0_stream(int twifd, uint16_t i2caddr, uint8_t *data, uint16_t bytes, uint16_t flags)
+{
+	struct i2c_rdwr_ioctl_data packets;
+	struct i2c_msg msg;
+	int ret = 0;
+
+	msg.addr = i2caddr;
+	msg.flags = flags;
+	msg.len = bytes;
+	msg.buf = data;
+
+	packets.msgs = &msg;
+	packets.nmsgs = 1;
+
+	/* I2C_RDWR will return < 0 on error, or the number of messages that
+	 * were transferred. We should always have one since we are only ever
+	 * sending a single transfer.
+	 */
+	ret = ioctl(twifd, I2C_RDWR, &packets);
+	if (ret < 0)
+		perror("Unable to transfer data");
+	else if (ret == 1)
+		ret = 0;
+	else
+		ret = -1;
+
+	return ret;
+}
+
+int v0_stream_read(int twifd, uint16_t i2caddr, uint8_t *data, uint16_t bytes)
+{
+	return __v0_stream(twifd, i2caddr, data, bytes, I2C_M_RD);
+}
+
+int v0_stream_write(int twifd, uint16_t i2caddr, uint8_t *data, uint16_t bytes)
+{
+	return __v0_stream(twifd, i2caddr, data, bytes, 0);
+}

--- a/src/micro.h
+++ b/src/micro.h
@@ -1,0 +1,9 @@
+#pragma once
+
+int speekstream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size);
+int spokestream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size);
+int micro_init(int i2cbus, uint16_t i2caddr);
+int spoke16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t data);
+int speek16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data);
+int v0_stream_write(int i2cfd, uint16_t i2caddr, uint8_t *data, uint16_t bytes);
+int v0_stream_read(int i2cfd, uint16_t i2caddr, uint8_t *data, uint16_t bytes);

--- a/src/tsmicroctl.c
+++ b/src/tsmicroctl.c
@@ -215,7 +215,7 @@ static int do_ts7970_info(int i2cfd)
 		// MAC is stored starting at offset 16
 		uint8_t *mac_bytes = (uint8_t *)&data[16];
 		printf("MAC=\"%02x:%02x:%02x:%02x:%02x:%02x\"\n",
-			mac_bytes[0], mac_bytes[1], mac_bytes[3],
+			mac_bytes[1], mac_bytes[0], mac_bytes[3],
 			mac_bytes[2], mac_bytes[5], mac_bytes[4]);
 	}
 


### PR DESCRIPTION
In testing with 6.6 in distro-seed I ran in to a few issues:

- Older TS-7970 microcontroller firmware revs would cause errors with tsmicroctl
- tsmicroctl would fail to report error states on exit for some situations that should be considered errors
- Improper argument sanitization and testing
- Corner cases with arguments that could cause issues when processing them
- Unnecessary variables used throughout the code
- Sleep commands having issues on resistive TS-TPC-7990 platforms.
- Improper use of `read()` and `write()` on I2C transactions now moved to use proper `ioctl()`s

This wraps all of these fixes up.

All changes were tested on:
- TS-TPC-7990 Rev C, resistive and capacitive touch
- TS-7970 Rev H PCB, Rev 16 microcontroller firmware
- TS-7970 Rev F PCB, Rev 2 microcontroller firmware
- TS-7970 Rev E PCB, Rev 4 microcontroller firmware
- All of the above with kernel 5.10 and 6.6