### PR TITLE
tshwctl: update to libgpiod 2.x API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AM_INIT_AUTOMAKE([1.00 foreign no-define])
 # Checks for programs.
 AC_PROG_CC
 
-PKG_CHECK_MODULES([LIBGPIOD], [libgpiod >= 1.4], [], [
+PKG_CHECK_MODULES([LIBGPIOD], [libgpiod >= 2.2], [], [
   AC_MSG_ERROR([libgpiod is required but was not found])
 ])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ isl12020rtc_SOURCES = isl12020rtc.c
 isl12020rtc_CPPFLAGS = -DCTL
 isl12020rtc_LDADD =
 
-tshwctl_SOURCES = tshwctl.c fpga.c
+tshwctl_SOURCES = tshwctl.c fpga.c gpiod-helper.c
 tshwctl_CPPFLAGS = $(LIBGPIOD_CFLAGS)
 tshwctl_LDADD = $(LIBGPIOD_LIBS) -lm
 

--- a/src/gpiod-helper.c
+++ b/src/gpiod-helper.c
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2023 Kent Gibson <warthog618@gmail.com>
+
+#include <errno.h>
+#include <gpiod.h>
+#include <stdio.h>
+
+/* The following helper functions were pulled mostly verbatim from the libgpiod
+ * examples. More information on each function is included in its header.
+ */
+
+/* Request a single line as an input.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_line_value.c
+ */
+
+struct gpiod_line_request *request_input_line(const char *chip_path,
+					      unsigned int offset,
+					      const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_INPUT);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1,
+						  settings);
+	if (ret)
+		goto free_line_config;
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}
+
+
+/* Request a single line as an output.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_line_value.c
+ */
+struct gpiod_line_request *
+request_output_line(const char *chip_path, unsigned int offset,
+		    enum gpiod_line_value value, const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings,
+					  GPIOD_LINE_DIRECTION_OUTPUT);
+	gpiod_line_settings_set_output_value(settings, value);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1,
+						  settings);
+	if (ret)
+		goto free_line_config;
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}

--- a/src/gpiod-helper.h
+++ b/src/gpiod-helper.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2023 Kent Gibson <warthog618@gmail.com>
+
+/* The following helper functions were pulled mostly verbatim from the libgpiod
+ * examples. More information on each function is included in its header.
+ */
+
+#pragma once
+
+#include <gpiod.h>
+#include <stdio.h>
+
+/* Request a single line as an input.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_line_value.c
+ */
+
+struct gpiod_line_request *request_input_line(const char *chip_path,
+					      unsigned int offset,
+					      const char *consumer);
+
+/* Request a single line as an output.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_line_value.c
+ */
+struct gpiod_line_request *
+request_output_line(const char *chip_path, unsigned int offset,
+		    enum gpiod_line_value value, const char *consumer);

--- a/src/tshwctl.c
+++ b/src/tshwctl.c
@@ -20,6 +20,7 @@
 #include "crossbar-ts4900.h"
 #include "crossbar-ts7970.h"
 #include "crossbar-ts7990.h"
+#include "gpiod-helper.h"
 
 static int i2cfd;
 
@@ -182,14 +183,15 @@ void auto485_en(int uart, int baud, char *mode)
 
 int do_ts7990_info(int i2cfd)
 {
-	struct gpiod_chip *cpu_chip1 = 0, *cpu_chip2 = 0, *cpu_chip4 = 0;
-	struct gpiod_line *rev_b_line = 0, *rev_d_line = 0, *rev_e_line = 0;
+	struct gpiod_line_request *rev_b_line = NULL,
+				  *rev_d_line = NULL,
+				  *rev_e_line = NULL;
 	uint8_t h12, g12, p13, l14;
 	uint8_t boardopt;
 	uint8_t fpgarev;
 	char pcbrev;
 	uint8_t val;
-	int value;
+	enum gpiod_line_value value;
 	int ret = 0;
 
 	val = fpeek8(i2cfd, 51);
@@ -204,52 +206,35 @@ int do_ts7990_info(int i2cfd)
 	printf("okaya_present=%d\n", !!(val & 0x8));
 	printf("lxd_present=%d\n", !!(val & 0x10));
 
-	cpu_chip1 = gpiod_chip_open("/dev/gpiochip1");
-	if (!cpu_chip1) {
-		perror("chip1: gpiod_chip_open");
+	rev_b_line = request_input_line("/dev/gpiochip2", 2, "tshwctl");
+	if (!rev_b_line) {
+		perror("Unable to open rev_b_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	cpu_chip2 = gpiod_chip_open("/dev/gpiochip2");
-	if (!cpu_chip2) {
-		perror("chip2: gpiod_chip_open");
+	rev_d_line = request_input_line("/dev/gpiochip4", 30, "tshwctl");
+	if (!rev_d_line) {
+		perror("Unable to open rev_d_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	cpu_chip4 = gpiod_chip_open("/dev/gpiochip4");
-	if (!cpu_chip4) {
-		perror("chip4: gpiod_chip_open");
+	rev_e_line = request_input_line("/dev/gpiochip1", 3, "tshwctl");
+	if (!rev_e_line) {
+		perror("Unable to open rev_e_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	rev_b_line = gpiod_chip_get_line(cpu_chip2, 2);
-	rev_d_line = gpiod_chip_get_line(cpu_chip4, 30);
-	rev_e_line = gpiod_chip_get_line(cpu_chip1, 3);
-	if (!rev_b_line || !rev_d_line || !rev_e_line) {
-		perror("gpiod_chip_get_line");
+	value = gpiod_line_request_get_value(rev_b_line, 2);
+	if (value == GPIOD_LINE_VALUE_ERROR) {
+		perror("rev_b_line read error");
 		ret = 1;
 		goto cleanup;
 	}
 
-	if (gpiod_line_request_input(rev_b_line, "tshwctl") < 0 ||
-	    gpiod_line_request_input(rev_d_line, "tshwctl") < 0 ||
-	    gpiod_line_request_input(rev_e_line, "tshwctl") < 0) {
-		perror("gpiod_line_request_input");
-		ret = 1;
-		goto cleanup;
-	}
-
-	value = gpiod_line_get_value(rev_b_line);
-	if (value < 0) {
-		perror("gpiod_line_get_value");
-		ret = 1;
-		goto cleanup;
-	}
-
-	if (value) {
+	if (value == GPIOD_LINE_VALUE_ACTIVE) {
 		pcbrev = 'A';
 	} else {
 		/* Rev < 10 couldn't read build resistors due
@@ -259,22 +244,22 @@ int do_ts7990_info(int i2cfd)
 		if (fpgarev < 10 || !g12) {
 			pcbrev = 'B';
 		} else {
-			value = gpiod_line_get_value(rev_d_line);
-			if (value < 0) {
-				perror("gpiod_line_get_value");
+			value = gpiod_line_request_get_value(rev_d_line, 30);
+			if (value == GPIOD_LINE_VALUE_ERROR) {
+				perror("rev_d_line read error");
 				ret = 1;
 				goto cleanup;
 			}
 
-			if (value == 0) {
-				value = gpiod_line_get_value(rev_e_line);
-				if (value < 0) {
-					perror("gpiod_line_get_value");
+			if (value == GPIOD_LINE_VALUE_INACTIVE) {
+				value = gpiod_line_request_get_value(rev_e_line, 3);
+				if (value == GPIOD_LINE_VALUE_ERROR) {
+					perror("rev_e_line read error");
 					ret = 1;
 					goto cleanup;
 				}
 
-				if (value == 0) {
+				if (value == GPIOD_LINE_VALUE_INACTIVE) {
 					pcbrev = 'E';
 				} else {
 					pcbrev = 'D';
@@ -292,45 +277,54 @@ int do_ts7990_info(int i2cfd)
 	printf("boardopt=%d\n", boardopt);
 
 cleanup:
-	if (cpu_chip1)
-		gpiod_chip_close(cpu_chip1);
-	if (cpu_chip2)
-		gpiod_chip_close(cpu_chip2);
-	if (cpu_chip4)
-		gpiod_chip_close(cpu_chip4);
+	if (rev_b_line)
+		gpiod_line_request_release(rev_b_line);
+	if (rev_d_line)
+		gpiod_line_request_release(rev_d_line);
+	if (rev_e_line)
+		gpiod_line_request_release(rev_e_line);
 
 	return ret;
 }
 
 int do_ts7970_info(int i2cfd)
 {
-	struct gpiod_chip *cpu_chip0 = 0, *cpu_chip1 = 0, *cpu_chip6 = 0;
-	struct gpiod_line *rev_b_line = 0, *rev_d_line = 0, *rev_g_line = 0, *rev_h_line = 0;
+	struct gpiod_line_request *rev_b_line = NULL,
+				  *rev_d_line = NULL,
+				  *rev_g_line = NULL,
+				  *rev_h_line = NULL;
 	uint8_t r39, r37, r36, r34;
 	uint8_t boardopt;
 	uint8_t fpgarev;
 	char pcbrev;
 	uint8_t val;
-	int value;
+	enum gpiod_line_value value;
 	int ret = 0;
 
-	cpu_chip0 = gpiod_chip_open("/dev/gpiochip0");
-	if (!cpu_chip0) {
-		perror("chip0: gpiod_chip_open");
+	rev_b_line = request_input_line("/dev/gpiochip6", 1, "tshwctl");
+	if (!rev_b_line) {
+		perror("Unable to open rev_b_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	cpu_chip1 = gpiod_chip_open("/dev/gpiochip1");
-	if (!cpu_chip1) {
-		perror("chip1: gpiod_chip_open");
+	rev_d_line = request_input_line("/dev/gpiochip6", 0, "tshwctl");
+	if (!rev_d_line) {
+		perror("Unable to open rev_d_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	cpu_chip6 = gpiod_chip_open("/dev/gpiochip6");
-	if (!cpu_chip6) {
-		perror("chip6: gpiod_chip_open");
+	rev_g_line = request_input_line("/dev/gpiochip0", 29, "tshwctl");
+	if (!rev_g_line) {
+		perror("Unable to open rev_e_line");
+		ret = 1;
+		goto cleanup;
+	}
+
+	rev_h_line = request_input_line("/dev/gpiochip1", 3, "tshwctl");
+	if (!rev_h_line) {
+		perror("Unable to open rev_e_line");
 		ret = 1;
 		goto cleanup;
 	}
@@ -344,43 +338,24 @@ int do_ts7970_info(int i2cfd)
 
 	boardopt = r34 | (r36 << 1) | (r37 << 2) | (r39 << 3);
 
-	rev_b_line = gpiod_chip_get_line(cpu_chip6, 1);
-	rev_d_line = gpiod_chip_get_line(cpu_chip6, 0);
-	rev_g_line = gpiod_chip_get_line(cpu_chip0, 29);
-	rev_h_line = gpiod_chip_get_line(cpu_chip1, 3);
-	if (!rev_b_line || !rev_d_line || !rev_g_line || !rev_h_line) {
-		perror("gpiod_chip_get_line");
+	value = gpiod_line_request_get_value(rev_h_line, 3);
+	if (value == GPIOD_LINE_VALUE_ERROR) {
+		perror("rev_h_line read error");
 		ret = 1;
 		goto cleanup;
 	}
 
-	if (gpiod_line_request_input(rev_b_line, "tshwctl") < 0 ||
-	    gpiod_line_request_input(rev_d_line, "tshwctl") < 0 ||
-	    gpiod_line_request_input(rev_g_line, "tshwctl") < 0 ||
-	    gpiod_line_request_input(rev_h_line, "tshwctl") < 0) {
-		perror("gpiod_line_request_input");
-		ret = 1;
-		goto cleanup;
-	}
-
-	value = gpiod_line_get_value(rev_h_line);
-	if (value < 0) {
-		perror("gpiod_line_get_value");
-		ret = 1;
-		goto cleanup;
-	}
-
-	if (value == 0) {
+	if (value == GPIOD_LINE_VALUE_INACTIVE) {
 		pcbrev = 'H';
 	} else {
-		value = gpiod_line_get_value(rev_g_line);
-		if (value < 0) {
-			perror("gpiod_line_get_value");
+		value = gpiod_line_request_get_value(rev_g_line, 29);
+		if (value == GPIOD_LINE_VALUE_ERROR) {
+			perror("rev_g_line read error");
 			ret = 1;
 			goto cleanup;
 		}
 
-		if (value == 0) {
+		if (value == GPIOD_LINE_VALUE_INACTIVE) {
 			pcbrev = 'G';
 		} else {
 			/* REV F required a fuse to check */
@@ -418,23 +393,23 @@ int do_ts7970_info(int i2cfd)
 			if (val & 0x1) {
 				pcbrev = 'F';
 			} else {
-				value = gpiod_line_get_value(rev_b_line);
-				if (value < 0) {
-					perror("gpiod_line_get_value");
+				value = gpiod_line_request_get_value(rev_b_line, 1);
+				if (value == GPIOD_LINE_VALUE_ERROR) {
+					perror("rev_b_line read error");
 					ret = 1;
 					goto cleanup;
 				}
 
-				if (value) {
+				if (value == GPIOD_LINE_VALUE_ACTIVE) {
 					pcbrev = 'A';
 				} else {
-					value = gpiod_line_get_value(rev_d_line);
-					if (value < 0) {
-						perror("gpiod_line_get_value");
+					value = gpiod_line_request_get_value(rev_d_line, 0);
+					if (value == GPIOD_LINE_VALUE_ERROR) {
+						perror("rev_d_line read error");
 						ret = 1;
 						goto cleanup;
 					}
-					if (value) {
+					if (value == GPIOD_LINE_VALUE_ACTIVE) {
 						pcbrev = 'B';
 					} else {
 						pcbrev = 'D';
@@ -450,24 +425,27 @@ int do_ts7970_info(int i2cfd)
 	printf("boardopt=%d\n", boardopt);
 
 cleanup:
-	if (cpu_chip0)
-		gpiod_chip_close(cpu_chip0);
-	if (cpu_chip1)
-		gpiod_chip_close(cpu_chip1);
-	if (cpu_chip6)
-		gpiod_chip_close(cpu_chip6);
+	if (rev_b_line)
+		gpiod_line_request_release(rev_b_line);
+	if (rev_d_line)
+		gpiod_line_request_release(rev_d_line);
+	if (rev_g_line)
+		gpiod_line_request_release(rev_g_line);
+	if (rev_h_line)
+		gpiod_line_request_release(rev_h_line);
 
 	return ret;
 }
 
 int do_ts4900_info(int i2cfd)
 {
-	struct gpiod_chip *cpu_chip0 = 0, *cpu_chip1 = 0, *cpu_chip5 = 0;
-	struct gpiod_line *rev_e_line = 0, *rev_b_line = 0, *rev_d_line = 0;
+	struct gpiod_line_request *rev_b_line = NULL,
+				  *rev_d_line = NULL,
+				  *rev_e_line = NULL;
 	uint8_t fpgarev;
 	char pcbrev;
 	uint8_t val;
-	int value;
+	enum gpiod_line_value value;
 	int ret = 0;
 
 	val = fpeek8(i2cfd, 51);
@@ -477,70 +455,54 @@ int do_ts4900_info(int i2cfd)
 	printf("g1=%d\n", !(val & 0x4));
 	printf("b1=%d\n", !(val & 0x8));
 
-	cpu_chip0 = gpiod_chip_open("/dev/gpiochip0");
-	if (!cpu_chip0) {
-		perror("chip0: gpiod_chip_open");
+	rev_b_line = request_input_line("/dev/gpiochip1", 11, "tshwctl");
+	if (!rev_b_line) {
+		perror("Unable to open rev_b_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	cpu_chip1 = gpiod_chip_open("/dev/gpiochip1");
-	if (!cpu_chip1) {
-		perror("chip1: gpiod_chip_open");
+	rev_d_line = request_input_line("/dev/gpiochip5", 5, "tshwctl");
+	if (!rev_d_line) {
+		perror("Unable to open rev_d_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	cpu_chip5 = gpiod_chip_open("/dev/gpiochip5");
-	if (!cpu_chip5) {
-		perror("chip5: gpiod_chip_open");
+	rev_e_line = request_input_line("/dev/gpiochip0", 29, "tshwctl");
+	if (!rev_e_line) {
+		perror("Unable to open rev_e_line");
 		ret = 1;
 		goto cleanup;
 	}
 
-	rev_b_line = gpiod_chip_get_line(cpu_chip1, 11);
-	rev_d_line = gpiod_chip_get_line(cpu_chip5, 5);
-	rev_e_line = gpiod_chip_get_line(cpu_chip0, 29);
-	if (!rev_d_line || !rev_b_line || !rev_e_line) {
-		perror("gpiod_chip_get_line");
+	value = gpiod_line_request_get_value(rev_e_line, 29);
+	if (value == GPIOD_LINE_VALUE_ERROR) {
+		perror("rev_e_line read error");
 		ret = 1;
 		goto cleanup;
 	}
 
-	if (gpiod_line_request_input(rev_e_line, "tshwctl") < 0 ||
-	    gpiod_line_request_input(rev_d_line, "tshwctl") < 0 ||
-	    gpiod_line_request_input(rev_b_line, "tshwctl") < 0) {
-		perror("gpiod_line_request_input");
-		ret = 1;
-		goto cleanup;
-	}
-
-	value = gpiod_line_get_value(rev_e_line);
-	if (value < 0) {
-		perror("gpiod_line_get_value");
-		ret = 1;
-		goto cleanup;
-	}
-	if (!value) {
+	if (value == GPIOD_LINE_VALUE_INACTIVE) {
 		pcbrev = 'E';
 	} else {
-		value = gpiod_line_get_value(rev_b_line);
-		if (value < 0) {
-			perror("gpiod_line_get_value");
+		value = gpiod_line_request_get_value(rev_b_line, 11);
+		if (value == GPIOD_LINE_VALUE_ERROR) {
+			perror("rev_e_line read error");
 			ret = 1;
 			goto cleanup;
 		}
-		if (value) {
+		if (value == GPIOD_LINE_VALUE_ACTIVE) {
 			pcbrev = 'A';
 		} else {
-			value = gpiod_line_get_value(rev_d_line);
-			if (value < 0) {
-				perror("gpiod_line_get_value");
+			value = gpiod_line_request_get_value(rev_d_line, 5);
+			if (value == GPIOD_LINE_VALUE_ERROR) {
+				perror("rev_d_line read error");
 				ret = 1;
 				goto cleanup;
 			}
 
-			if (value) {
+			if (value == GPIOD_LINE_VALUE_ACTIVE) {
 				pcbrev = 'C';
 			} else {
 				pcbrev = 'D';
@@ -553,12 +515,12 @@ int do_ts4900_info(int i2cfd)
 	printf("pcbrev=%c\n", pcbrev);
 
 cleanup:
-	if (cpu_chip0)
-		gpiod_chip_close(cpu_chip0);
-	if (cpu_chip1)
-		gpiod_chip_close(cpu_chip1);
-	if (cpu_chip5)
-		gpiod_chip_close(cpu_chip5);
+	if (rev_b_line)
+		gpiod_line_request_release(rev_b_line);
+	if (rev_d_line)
+		gpiod_line_request_release(rev_d_line);
+	if (rev_e_line)
+		gpiod_line_request_release(rev_e_line);
 
 	return ret;
 }


### PR DESCRIPTION
Update to use libgpiod 2.x API, Fixes #11 

Tested against:
- TS-4900
  - Rev A
  - Rev B
  - Rev D
  - Rev E

- TS-7970
  - Rev B
  - Rev D/E
  - Rev F (fails to correctly ID on both new and old, however, IDs as Rev D)
  - Rev H

- TS-TPC-7990
  - Rev C


This should be considered a major rev bump of `ts4900-utils`. Support for this in https://github.com/embeddedTS/buildroot-ts needs move to libgpiod2. Similar for https://github.com/embeddedTS/meta-ts/ needs to be updated and then the limit of prefer libgpiod 1.x removed.